### PR TITLE
Add RMarkdown.

### DIFF
--- a/source/index.json
+++ b/source/index.json
@@ -204,6 +204,7 @@
   "rhtml",
   "rjs",
   "rlib",
+  "rmd",
   "ron",
   "rs",
   "rss",


### PR DESCRIPTION
This adds the file extension for [RMarkdown](https://rmarkdown.rstudio.com/).