### PR TITLE
Fix module not found error and add cjs extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,8 +233,8 @@
     "node": {
       "types": "./edition-types/index.d.ts",
       "import": "./edition-es2022-esm/index.js",
-      "default": "./index.cjs",
-      "require": "./edition-es2022/index.js"
+      "require": "./edition-es2022/index.js",
+      "default": "./index.cjs"
     },
     "browser": {
       "types": "./edition-types/index.d.ts",

--- a/source/index.ts
+++ b/source/index.ts
@@ -31,6 +31,7 @@ const list = [
 	'cfm',
 	'cfml',
 	'cgi',
+	'cjs',
 	'clj',
 	'cls',
 	'cmake',


### PR DESCRIPTION
1. Add cjs extension to the list
2. Fix `Module not found: Error: Default condition should be last one` issue.
Here are some similar ones:
  * https://github.com/mpociot/chatgpt-vscode/issues/1
  * https://stackoverflow.com/questions/76127288/module-not-found-error-default-condition-should-be-last-one